### PR TITLE
Removed the visible form from Dimensions

### DIFF
--- a/app/views/potagers/new.html.erb
+++ b/app/views/potagers/new.html.erb
@@ -63,10 +63,8 @@
               <div class="form">
                 <p> </p>
                 <%= form_tag("/search", method: "get") do %>
-                  <%= label_tag(:q, "Largeur :") %>
-                  <%= text_field_tag(:largeur) %>
-                  <%= label_tag(:q, "Longueur :") %>
-                  <%= text_field_tag(:longueur) %>
+                  <%= hidden_field_tag(:largeur) %>
+                  <%= hidden_field_tag(:longueur) %>
                 <% end %>
               </div>
             </div>


### PR DESCRIPTION
I've found a way to hide the form fields containing the length and width of the potager. The data is still there in the source code for future use when creating the instance of Potager. 